### PR TITLE
Update Actions and Documentation to accommodate Latest Ansible and corresponding Python versions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: ansible-community/ansible-test-gh-action@v1.15.0
+      - uses: ansible-community/ansible-test-gh-action@v1.17.0
         with:
           collection-src-directory: infoblox.universal_ddi
           ansible-core-version: 'stable-2.20'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,9 +23,14 @@ jobs:
           echo "portal_key: ${{ secrets.INFOBLOX_PORTAL_KEY }}" > infoblox.universal_ddi/tests/integration/integration_config.yml
           echo "portal_url: ${{ secrets.INFOBLOX_PORTAL_URL }}" >> infoblox.universal_ddi/tests/integration/integration_config.yml
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - uses: ansible-community/ansible-test-gh-action@v1.15.0
         with:
           collection-src-directory: infoblox.universal_ddi
-          ansible-core-version: 'stable-2.15'
-          target-python-version: '3.11'
+          ansible-core-version: 'stable-2.20'
+          target-python-version: '3.12'
           testing-type: integration

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,11 +9,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible: [ 'stable-2.15', 'stable-2.16', 'stable-2.17', 'devel' ]
-        python: [ '3.9', '3.10', '3.11', '3.12' ]
+        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'devel' ]
+        python: [ '3.10', '3.11', '3.12', '3.13' ]
         exclude:
-          - ansible: 'stable-2.15'
-            python: '3.12'
+          - ansible: 'stable-2.16'
+            python: '3.13'
+          - ansible: 'stable-2.17'
+            python: '3.13'
+          - ansible: 'stable-2.18'
+            python: '3.10'
+          - ansible: 'stable-2.19'
+            python: '3.10'
+          - ansible: 'devel'
+            python: '3.10'
+          - ansible: 'devel'
+            python: '3.11'
+        include:
+            - ansible: 'devel'
+              python: '3.14'
+
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'devel' ]
+        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'stable-2.20', 'devel' ]
         python: [ '3.10', '3.11', '3.12', '3.13' ]
         exclude:
           - ansible: 'stable-2.16'
@@ -20,12 +20,18 @@ jobs:
             python: '3.10'
           - ansible: 'stable-2.19'
             python: '3.10'
+          - ansible: 'stable-2.20'
+            python: '3.11'
+          - ansible: 'stable-2.20'
+            python: '3.10'
           - ansible: 'devel'
             python: '3.10'
           - ansible: 'devel'
             python: '3.11'
         include:
             - ansible: 'devel'
+              python: '3.14'
+            - ansible: 'stable-2.20'
               python: '3.14'
 
     steps:
@@ -34,7 +40,12 @@ jobs:
         with:
           path: infoblox.universal_ddi
 
-      - uses: ansible-community/ansible-test-gh-action@v1.15.0
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - uses: ansible-community/ansible-test-gh-action@v1.17.0
         with:
           collection-src-directory: infoblox.universal_ddi
           ansible-core-version: ${{ matrix.ansible }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'stable-2.20', 'devel' ]
+        # TODO : Add devel to the ansible matrix
+        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'stable-2.20']
         python: [ '3.10', '3.11', '3.12', '3.13' ]
         exclude:
           - ansible: 'stable-2.16'
@@ -24,10 +25,6 @@ jobs:
             python: '3.11'
           - ansible: 'stable-2.20'
             python: '3.10'
-          - ansible: 'devel'
-            python: '3.10'
-          - ansible: 'devel'
-            python: '3.11'
         include:
             - ansible: 'stable-2.20'
               python: '3.14'

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -29,8 +29,6 @@ jobs:
           - ansible: 'devel'
             python: '3.11'
         include:
-            - ansible: 'devel'
-              python: '3.14'
             - ansible: 'stable-2.20'
               python: '3.14'
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # TODO : Add devel to the ansible matrix
-        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'stable-2.20']
+        ansible: [ 'stable-2.16', 'stable-2.17', 'stable-2.18', 'stable-2.19', 'stable-2.20', 'stable-2.21' ]
         python: [ '3.10', '3.11', '3.12', '3.13' ]
         exclude:
           - ansible: 'stable-2.16'
@@ -25,8 +25,14 @@ jobs:
             python: '3.11'
           - ansible: 'stable-2.20'
             python: '3.10'
+          - ansible: 'stable-2.21'
+            python: '3.11'
+          - ansible: 'stable-2.21'
+            python: '3.10'
         include:
             - ansible: 'stable-2.20'
+              python: '3.14'
+            - ansible: 'stable-2.21'
               python: '3.14'
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ celerybeat.pid
 .env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/plugins/modules/dns_record.py
+++ b/plugins/modules/dns_record.py
@@ -841,32 +841,32 @@ item:
                     - "Record was created automatically based on the DTC configuration. Always extends the I(SYSTEM) bit. Valid only for I(IBMETA) record type with I(LBDN) subtype."
                   type: str
                   returned: Always
-                STATIC, SYSTEM:
+                STATIC_SYSTEM:
                   description: 
                     - "Record was created manually by API call but it is obfuscated by record generated based on name server assignment."
                   type: str
                   returned: Always
-                DYNAMIC, SYSTEM:
+                DYNAMIC_SYSTEM:
                   description: 
                     - "Record was created dynamically by DDNS but it is obfuscated by record generated based on name server assignment."
                   type: str
                   returned: Always
-                DELEGATED, SYSTEM:
+                DELEGATED_SYSTEM:
                   description: 
                     - "Record was created automatically based on delegation servers assignment. I(SYSTEM) will always accompany I(DELEGATED)."
                   type: str
                   returned: Always
-                DTC, SYSTEM:
+                DTC_SYSTEM:
                   description: 
                     - "Record was created automatically based on the DTC configuration. I(SYSTEM) will always accompany I(DTC)."
                   type: str
                   returned: Always
-                STATIC, SYSTEM, DELEGATED:
+                STATIC_SYSTEM_DELEGATED:
                   description: 
                     - "Record was created manually by API call but it is obfuscated by record generated based on name server assignment as a result of creating a delegation."
                   type: str
                   returned: Always
-                DYNAMIC, SYSTEM, DELEGATED:
+                DYNAMIC_SYSTEM_DELEGATED:
                   description: 
                     - "Record was created dynamically by DDNS but it is obfuscated by record generated based on name server assignment as a result of creating a delegation."
                   type: str

--- a/plugins/modules/dns_record_info.py
+++ b/plugins/modules/dns_record_info.py
@@ -444,32 +444,32 @@ objects:
                     - "Record was created automatically based on the DTC configuration. Always extends the I(SYSTEM) bit. Valid only for I(IBMETA) record type with I(LBDN) subtype."
                   type: str
                   returned: Always
-                STATIC, SYSTEM:
+                STATIC_SYSTEM:
                   description: 
                     - "Record was created manually by API call but it is obfuscated by record generated based on name server assignment."
                   type: str
                   returned: Always
-                DYNAMIC, SYSTEM:
+                DYNAMIC_SYSTEM:
                   description: 
                     - "Record was created dynamically by DDNS but it is obfuscated by record generated based on name server assignment."
                   type: str
                   returned: Always
-                DELEGATED, SYSTEM:
+                DELEGATED_SYSTEM:
                   description: 
                     - "Record was created automatically based on delegation servers assignment. I(SYSTEM) will always accompany I(DELEGATED)."
                   type: str
                   returned: Always
-                DTC, SYSTEM:
+                DTC_SYSTEM:
                   description: 
                     - "Record was created automatically based on the DTC configuration. I(SYSTEM) will always accompany I(DTC)."
                   type: str
                   returned: Always
-                STATIC, SYSTEM, DELEGATED:
+                STATIC_SYSTEM_DELEGATED:
                   description: 
                     - "Record was created manually by API call but it is obfuscated by record generated based on name server assignment as a result of creating a delegation."
                   type: str
                   returned: Always
-                DYNAMIC, SYSTEM, DELEGATED:
+                DYNAMIC_SYSTEM_DELEGATED:
                   description: 
                     - "Record was created dynamically by DDNS but it is obfuscated by record generated based on name server assignment as a result of creating a delegation."
                   type: str

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,3 @@
+---
+modules:
+  python_requires: ">=3.9"

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,0 @@
----
-modules:
-  python_requires: ">=3.9"


### PR DESCRIPTION
This PR Contains :

- Update Sanity Matrix to Accommodate Latest Versions
- Update Integration Action to use Ansible 2.20 with Python 2.12
- Update `dns_record` and `dns_record` documentation to remove `,` from text